### PR TITLE
comunicação inicial com Spring Cloud Load Balancer

### DIFF
--- a/.run/HrPayrollApplication.run.xml
+++ b/.run/HrPayrollApplication.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="HrPayrollApplication" type="Application" factoryName="Application" nameIsGenerated="true">
+    <option name="MAIN_CLASS_NAME" value="com.devsuperior.hrpayroll.HrPayrollApplication" />
+    <module name="hr-payroll" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="com.devsuperior.hrpayroll.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/HrWorkerApplication_8001.run.xml
+++ b/.run/HrWorkerApplication_8001.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="HrWorkerApplication:8001" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="com.devsuperior.hrworker.HrWorkerApplication" />
+    <module name="hr-worker" />
+    <option name="PROGRAM_PARAMETERS" value="--server.port=8001" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="com.devsuperior.hrworker.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/HrWorkerApplication_8002.run.xml
+++ b/.run/HrWorkerApplication_8002.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="HrWorkerApplication:8002" type="Application" factoryName="Application">
+    <option name="MAIN_CLASS_NAME" value="com.devsuperior.hrworker.HrWorkerApplication" />
+    <module name="hr-worker" />
+    <option name="PROGRAM_PARAMETERS" value="--server.port=8002" />
+    <extension name="coverage">
+      <pattern>
+        <option name="PATTERN" value="com.devsuperior.hrworker.*" />
+        <option name="ENABLED" value="true" />
+      </pattern>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/hr-payroll/pom.xml
+++ b/hr-payroll/pom.xml
@@ -47,6 +47,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-loadbalancer</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>

--- a/hr-payroll/src/main/java/com/devsuperior/hrpayroll/feign/WorkerFeignClient.java
+++ b/hr-payroll/src/main/java/com/devsuperior/hrpayroll/feign/WorkerFeignClient.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 
 @Component
-@FeignClient(name = "hr-worker", url = "http://localhost:8001", path = "/workers")
+@FeignClient(name = "hr-worker", path = "/workers")
 public interface WorkerFeignClient {
 
     @GetMapping(value = "/{id_worker}")

--- a/hr-payroll/src/main/resources/application.properties
+++ b/hr-payroll/src/main/resources/application.properties
@@ -1,4 +1,5 @@
 spring.application.name=hr-payroll
 server.port=8101
 
-hr-worker.host.url=http://localhost:8001
+spring.cloud.discovery.client.simple.instances.hr-worker[0].uri=http://localhost:8001
+spring.cloud.discovery.client.simple.instances.hr-worker[1].uri=http://localhost:8002

--- a/hr-worker/src/main/java/com/devsuperior/hrworker/resources/WorkerEndpoint.java
+++ b/hr-worker/src/main/java/com/devsuperior/hrworker/resources/WorkerEndpoint.java
@@ -2,6 +2,9 @@ package com.devsuperior.hrworker.resources;
 
 import com.devsuperior.hrworker.entities.Worker;
 import com.devsuperior.hrworker.repositories.WorkerRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -16,9 +19,13 @@ import java.util.Optional;
 @RequestMapping(value = "/workers")
 public class WorkerEndpoint {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(WorkerEndpoint.class);
+
+    private final Environment applicationEnvironment;
     private final WorkerRepository workerRepository;
 
-    public WorkerEndpoint(WorkerRepository workerRepository) {
+    public WorkerEndpoint(Environment applicationEnvironment, WorkerRepository workerRepository) {
+        this.applicationEnvironment = applicationEnvironment;
         this.workerRepository = workerRepository;
     }
 
@@ -30,6 +37,8 @@ public class WorkerEndpoint {
 
     @GetMapping(value = "/{id_worker}")
     public ResponseEntity<Worker> getWorkers(@PathVariable("id_worker") Long id) {
+        LOGGER.info("hr-worker serving on port: " + applicationEnvironment.getProperty("server.port"));
+
         final Optional<Worker> optionalWorker = this.workerRepository.findById(id);
         final Worker worker = optionalWorker.orElseThrow(() -> new EntityNotFoundException("Trabalhador não encontrado"));
         return ResponseEntity.ok(worker);


### PR DESCRIPTION
- **WorkerFeignClient**: remoção do atributo **url** estatico.
- **WorkerEndpoint**: LOGGER para imprimir a porta que a instância da aplicação está ocupando.
- **pom.xml**: adicionado starter do Spring Cloud Load Balancer
- **application.properties(hr-payroll)**: endereço(s) e portas onde o **hr-worker** estará disponível.
- **.run/**: diretório com as configurações para executar **hr-payroll** e **hr-worker**.
- **documentações**:
    - [1.1. How to Include Feign](https://docs.spring.io/spring-cloud-openfeign/docs/4.0.2/reference/html/#netflix-feign-starter)
    - [2.1.3. SimpleDiscoveryClient](https://docs.spring.io/spring-cloud-commons/docs/current/reference/html/#simplediscoveryclient)